### PR TITLE
Add Node.js snapshot test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "context": "tsx scripts/context-map.ts",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "lint": "oxlint scripts"
   },
   "keywords": [],

--- a/test/context-map.test.js
+++ b/test/context-map.test.js
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const execFileP = promisify(execFile);
+
+test('context-map fetchData snapshot', async () => {
+  const { stdout } = await execFileP(
+    'npx',
+    ['tsx', 'scripts/context-map.ts', 'fetchData', '-r', 'src', '-a', '-o', 'markdown'],
+    { encoding: 'utf8' }
+  );
+  const expected = await readFile(resolve(__dirname, 'fixtures', 'context-fetchData.md'), 'utf8');
+  assert.strictEqual(stdout, expected);
+});

--- a/test/fixtures/context-fetchData.md
+++ b/test/fixtures/context-fetchData.md
@@ -1,0 +1,14 @@
+### src/a.ts
+
+```ts
+import b from './b'
+export const foo = "bar";
+export function fetchData() { return b(); }
+
+```
+### src/b.ts
+
+```ts
+export default function b() { return 42; }
+
+```


### PR DESCRIPTION
## Summary
- run the built script and store the markdown output in a fixture
- compare current CLI output with the fixture using the Node.js test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687207d07f948325b10eb22e785fef0a