### PR TITLE
Add Deno lint tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ import dependencies.
 
 Install [Deno](https://deno.land/).
 
+Lint with `deno lint`:
+
+```bash
+deno task lint
+```
+
+Format with `deno fmt`:
+
+```bash
+deno task format
+```
+
 ## Usage
 
 ```bash

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,9 @@
   "tasks": {
     "context": "deno run --allow-read scripts/context-map.ts",
     "test": "deno test --allow-run --allow-read",
-    "build": "deno compile --allow-read -o context-map scripts/context-map.ts"
+    "build": "deno compile --allow-read -o context-map scripts/context-map.ts",
+    "lint": "deno lint",
+    "format": "deno fmt"
   },
   "compilerOptions": {
     "target": "ES2020"

--- a/scripts/context-map.ts
+++ b/scripts/context-map.ts
@@ -195,11 +195,11 @@ function findDependents(graph: DirectedGraph, entries: string[]): Set<string> {
   return visited;
 }
 
-async function buildClosure(
+function buildClosure(
   graph: DirectedGraph,
   entries: string[],
   maxDepth: number,
-): Promise<Set<string>> {
+): Set<string> {
   const visited = new Set<string>();
   const queue: Array<{ file: string; depth: number }> = entries.map((f) => ({
     file: f,
@@ -233,8 +233,12 @@ async function outputFiles(files: string[], format: string, maxLines: number) {
   }
 }
 
+interface Tree {
+  [key: string]: Tree;
+}
+
 function generateFileTree(paths: string[]): string {
-  const root: Record<string, any> = {};
+  const root: Tree = {};
   for (const p of paths) {
     const parts = p.split("/");
     let node = root;
@@ -244,7 +248,7 @@ function generateFileTree(paths: string[]): string {
     }
   }
   const lines = ["."];
-  const traverse = (node: Record<string, any>, prefix: string) => {
+  const traverse = (node: Tree, prefix: string) => {
     const entries = Object.keys(node).sort();
     for (let i = 0; i < entries.length; i++) {
       const name = entries[i];
@@ -306,7 +310,7 @@ async function main() {
     const parents = findDependents(graph, selected);
     entries = [...new Set([...selected, ...parents])];
   }
-  const closure = await buildClosure(
+  const closure = buildClosure(
     graph,
     entries,
     opts.depth > 0 ? opts.depth : Infinity,


### PR DESCRIPTION
## Summary
- add documentation for running `deno lint` and `deno fmt`
- provide `lint` and `format` tasks in `deno.json`
- fix lint errors in `scripts/context-map.ts`

## Testing
- `deno task lint`
- `deno task test`


------
https://chatgpt.com/codex/tasks/task_e_687347f43aa08325a435f9c3ce84fd6b