### PR TITLE
Fix invalid compilerOptions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,8 +5,5 @@
     "build": "deno compile --allow-read -o context-map scripts/context-map.ts",
     "lint": "deno lint",
     "format": "deno fmt"
-  },
-  "compilerOptions": {
-    "target": "ES2020"
   }
 }


### PR DESCRIPTION
## Summary
- remove `compilerOptions` from deno.json

## Testing
- `deno fmt --check`
- `deno lint`
- `deno test --allow-run --allow-read`


------
https://chatgpt.com/codex/tasks/task_e_6873690c58d88325b5cf6630547b1d82